### PR TITLE
Support ministers holding multiple portfolios

### DIFF
--- a/components/CabinetFormation.tsx
+++ b/components/CabinetFormation.tsx
@@ -27,11 +27,12 @@ export const CabinetFormation: React.FC<CabinetFormationProps> = ({ onComplete }
   const [selectedRole, setSelectedRole] = useState<string | null>(null);
   const [showRisks, setShowRisks] = useState(false);
   const [currentRisks, setCurrentRisks] = useState<string[]>([]);
-  const { 
-    availableCandidates, 
+  const {
+    availableCandidates,
     selectedMinisters,
+    ministerRoles,
     maxPartyMinistersAllowed,
-    appointMinister 
+    appointMinister
   } = useCabinetFormationStore();
 
   // Filtrer les candidats disponibles pour le rôle sélectionné
@@ -39,11 +40,16 @@ export const CabinetFormation: React.FC<CabinetFormationProps> = ({ onComplete }
     if (!selectedRole) return [];
     
     return availableCandidates.filter(candidate => {
-      const partyCount = Object.values(selectedMinisters)
-        .filter(m => m.party === candidate.party).length;
+      const partyCount = Object.entries(ministerRoles).reduce((acc, [minId, roles]) => {
+        const m = selectedMinisters[minId];
+        if (m && m.party === candidate.party) {
+          acc += roles.length;
+        }
+        return acc;
+      }, 0);
       return partyCount < (maxPartyMinistersAllowed[candidate.party] || 0);
     });
-  }, [selectedRole, availableCandidates, selectedMinisters, maxPartyMinistersAllowed]);
+  }, [selectedRole, availableCandidates, selectedMinisters, ministerRoles, maxPartyMinistersAllowed]);
 
   const handleCandidateSelect = async (candidate: PotentialMinister) => {
     if (!selectedRole) return;

--- a/components/CouncilScreen.tsx
+++ b/components/CouncilScreen.tsx
@@ -25,7 +25,7 @@ const CouncilScreen: React.FC = () => {
           <div key={roleId} className="minister-card">
             <div className="minister-header">
               <h3>{minister.name}</h3>
-              <span className="minister-role">{minister.role}</span>
+              <span className="minister-role">{minister.roles.join(', ')}</span>
             </div>
 
             <div className="minister-stats">

--- a/src/store/cabinetStore.ts
+++ b/src/store/cabinetStore.ts
@@ -2,13 +2,16 @@ import { create } from 'zustand';
 import type { Minister, MinisterMission } from '../types/cabinet';
 
 interface CabinetState {
+  /** Mapping of role id to the minister holding it */
   ministers: Record<string, Minister>;
+  /** Mapping of minister id to all roles they currently hold */
+  ministerRoles: Record<string, string[]>;
   availableCandidates: Minister[];
   missions: MinisterMission[];
-  assignMission: (ministerId: string, missionId: string) => void;
+  assignMission: (roleId: string, missionId: string) => void;
   replaceMinister: (roleId: string, newMinisterId: string) => void;
-  updateMissionProgress: (ministerId: string, missionId: string) => void;
-  evaluateMissionResults: (ministerId: string, missionId: string) => void;
+  updateMissionProgress: (roleId: string, missionId: string) => void;
+  evaluateMissionResults: (roleId: string, missionId: string) => void;
 }
 
 export const useCabinetStore = create<CabinetState>((set, get) => ({
@@ -16,7 +19,7 @@ export const useCabinetStore = create<CabinetState>((set, get) => ({
     'premier-ministre': {
       id: 'pm1',
       name: 'Gabriel Attal',
-      role: 'Premier Ministre',
+      roles: ['premier-ministre'],
       loyalty: 85,
       competence: 75,
       popularity: 65,
@@ -26,19 +29,22 @@ export const useCabinetStore = create<CabinetState>((set, get) => ({
     },
     // ... autres ministres
   },
+  ministerRoles: {
+    'pm1': ['premier-ministre']
+  },
 
   availableCandidates: [],
   missions: [],
 
-  assignMission: (ministerId, missionId) => {
-    const minister = get().ministers[ministerId];
+  assignMission: (roleId, missionId) => {
+    const minister = get().ministers[roleId];
     const mission = get().missions.find(m => m.id === missionId);
     if (!minister || !mission) return;
 
     set(state => ({
       ministers: {
         ...state.ministers,
-        [ministerId]: {
+        [roleId]: {
           ...minister,
           missions: [...(minister.missions || []), {
             id: missionId,
@@ -56,16 +62,30 @@ export const useCabinetStore = create<CabinetState>((set, get) => ({
     const newMinister = get().availableCandidates.find(c => c.id === newMinisterId);
     if (!newMinister) return;
 
-    set(state => ({
-      ministers: {
-        ...state.ministers,
-        [roleId]: {
-          ...newMinister,
-          role: roleId,
-          status: 'active'
-        }
-      },
-      availableCandidates: state.availableCandidates.filter(c => c.id !== newMinisterId)
-    }));
+    set(state => {
+      const previous = state.ministers[roleId];
+      const rolesForNew = state.ministerRoles[newMinister.id] || [];
+      const updatedNewRoles = Array.from(new Set([...rolesForNew, roleId]));
+
+      const updatedRoles = { ...state.ministerRoles, [newMinister.id]: updatedNewRoles };
+
+      if (previous) {
+        const prevRoles = (state.ministerRoles[previous.id] || []).filter(r => r !== roleId);
+        updatedRoles[previous.id] = prevRoles;
+      }
+
+      return {
+        ministers: {
+          ...state.ministers,
+          [roleId]: {
+            ...newMinister,
+            roles: updatedNewRoles,
+            status: 'active'
+          }
+        },
+        ministerRoles: updatedRoles,
+        availableCandidates: state.availableCandidates.filter(c => c.id !== newMinisterId)
+      };
+    });
   }
 }));

--- a/src/types/cabinet.ts
+++ b/src/types/cabinet.ts
@@ -1,7 +1,11 @@
 export interface Minister {
   id: string;
   name: string;
-  role: string;
+  /**
+   * A minister may hold several portfolios simultaneously.
+   * Each entry in this array is a role identifier from CABINET_ROLES.
+   */
+  roles: string[];
   party: string;
   loyalty: number;
   competence: number;


### PR DESCRIPTION
## Summary
- allow one minister to be linked to more than one cabinet role
- keep track of which roles each minister holds
- expose minister roles in the council screen
- update cabinet formation logic to count multi‑role appointments correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails to run TypeScript build)*

------
https://chatgpt.com/codex/tasks/task_e_684955f89db0832cb17473e48e2f0ffe