### PR TITLE
Persist PM selection, improve candidates

### DIFF
--- a/components/CabinetFormation.tsx
+++ b/components/CabinetFormation.tsx
@@ -74,29 +74,18 @@ export const CabinetFormation: React.FC<CabinetFormationProps> = ({ onComplete }
     setCurrentRisks([]);
   };
 
-  // Ajouter console.log pour déboguer
-  console.log('Available candidates:', availableCandidates);
-  console.log('Filtered candidates:', filteredCandidates);
-  console.log('Selected role:', selectedRole);
-
-  const debugInfo = process.env.NODE_ENV === 'development' && (
-    <div style={{ margin: '1rem', padding: '1rem', background: '#f5f5f5' }}>
-      <p>Nombre total de candidats: {availableCandidates.length}</p>
-      <p>Candidats filtrés: {filteredCandidates.length}</p>
-      <p>Rôle sélectionné: {selectedRole}</p>
-      <p>Quotas par parti: {JSON.stringify(maxPartyMinistersAllowed)}</p>
-    </div>
+  const rolesToDisplay = CABINET_ROLES.filter(
+    r => !(r.id === 'premier-ministre' && selectedMinisters['premier-ministre'])
   );
 
   return (
     <div className="cabinet-formation">
-      {debugInfo}
       <h2>Formation du Gouvernement</h2>
 
       <div className="roles-section">
         <h3>Postes ministériels</h3>
         <div className="role-grid">
-          {CABINET_ROLES.map(role => (
+          {rolesToDisplay.map(role => (
             <button
               key={role.id}
               onClick={() => setSelectedRole(role.id)}
@@ -128,7 +117,7 @@ export const CabinetFormation: React.FC<CabinetFormationProps> = ({ onComplete }
                     <div className="stat">
                       <span>Compétence</span>
                       <div className="stat-bar">
-                        <div 
+                        <div
                           className="stat-fill"
                           style={{width: `${candidate.competence}%`}}
                         />
@@ -137,9 +126,18 @@ export const CabinetFormation: React.FC<CabinetFormationProps> = ({ onComplete }
                     <div className="stat">
                       <span>Loyauté</span>
                       <div className="stat-bar">
-                        <div 
+                        <div
                           className="stat-fill"
                           style={{width: `${candidate.personality.loyalty}%`}}
+                        />
+                      </div>
+                    </div>
+                    <div className="stat">
+                      <span>Réputation</span>
+                      <div className="stat-bar">
+                        <div
+                          className="stat-fill"
+                          style={{width: `${candidate.reputation}%`}}
                         />
                       </div>
                     </div>
@@ -151,6 +149,7 @@ export const CabinetFormation: React.FC<CabinetFormationProps> = ({ onComplete }
                     {candidate.personality.ambition > 80 && (
                       <span className="trait warning">Ambitieux</span>
                     )}
+                    <span className="trait">{candidate.experience} ans d'expérience</span>
                   </div>
                 </button>
               ))}

--- a/components/InitGameScreen.tsx
+++ b/components/InitGameScreen.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useGameState } from '../src/store/gameState';
 import { useCabinetFormationStore } from '../src/store/cabinetFormationStore';
-import type { GameInitStep, PoliticalParty, PotentialMinister } from '../src/types/game';
+import { getSeatDistribution } from '../src/utils/seatDistribution';
+import type { GameInitStep, PoliticalParty } from '../src/types/game';
+import type { PotentialMinister } from '../src/types/cabinet';
 import { PartySelector } from './PartySelector';
 import { PrimeMinisterSelector } from './PrimeMinisterSelector';
 import { CabinetFormation } from './CabinetFormation';
@@ -40,7 +42,8 @@ export const InitGameScreen: React.FC<{ onComplete: () => void }> = ({ onComplet
 
   const handlePrimeMinisterSelect = (minister: PotentialMinister) => {
     if (playerInfo.party) {
-      initializeFormation(playerInfo.party.id, { [minister.party]: 100 });
+      const seats = getSeatDistribution();
+      initializeFormation(playerInfo.party.id, seats, minister);
       setStep('cabinet');
     }
   };

--- a/components/PrimeMinisterSelector.tsx
+++ b/components/PrimeMinisterSelector.tsx
@@ -1,15 +1,7 @@
 import React, { useMemo } from 'react';
 import type { PotentialMinister } from '../src/types/cabinet';
 import { generateCandidates } from '../src/utils/candidateGenerator';
-import { PRESET_PARTIES } from '../src/store/gameState';
-
-const SEAT_DISTRIBUTION: Record<string, number> = PRESET_PARTIES.reduce(
-  (acc, p) => {
-    acc[p.id] = p.seatsInParliament;
-    return acc;
-  },
-  {} as Record<string, number>
-);
+import { getSeatDistribution } from '../src/utils/seatDistribution';
 
 interface Props {
   presidentParty: string;
@@ -18,7 +10,8 @@ interface Props {
 
 export const PrimeMinisterSelector: React.FC<Props> = ({ presidentParty, onSelect }) => {
   const candidates = useMemo(() => {
-    const pool = generateCandidates(presidentParty, SEAT_DISTRIBUTION, { primeMinister: true });
+    const seatDist = getSeatDistribution();
+    const pool = generateCandidates(presidentParty, seatDist, { primeMinister: true });
     return pool
       .filter((c: PotentialMinister) => c.competence >= 70)
       .sort((a, b) => b.competence - a.competence);

--- a/src/store/cabinetFormationStore.ts
+++ b/src/store/cabinetFormationStore.ts
@@ -11,7 +11,7 @@ interface CabinetFormationState {
   availableCandidates: PotentialMinister[];
   maxPartyMinistersAllowed: Record<string, number>;
   presidentParty: string;
-  initializeFormation: (presidentParty: string, parliamentSeats: Record<string, number>) => void;
+  initializeFormation: (presidentParty: string, parliamentSeats: Record<string, number>, primeMinister?: PotentialMinister) => void;
   appointMinister: (role: string, candidate: PotentialMinister) => Promise<{ risks: string[] }>;
 }
 
@@ -22,7 +22,7 @@ export const useCabinetFormationStore = create<CabinetFormationState>((set, get)
   maxPartyMinistersAllowed: {},
   presidentParty: '',
 
-  initializeFormation: (presidentParty, parliamentSeats) => {
+  initializeFormation: (presidentParty, parliamentSeats, primeMinister) => {
     const maxMinisters = Math.floor(Object.values(parliamentSeats).reduce((sum, seats) => sum + seats, 0) * 0.15);
     const partyAllocations: Record<string, number> = {};
     
@@ -34,12 +34,23 @@ export const useCabinetFormationStore = create<CabinetFormationState>((set, get)
     // Générer les candidats initiaux à partir du générateur commun
     const initialCandidates = generateCandidates(presidentParty, parliamentSeats);
     
+    const selectedMinisters: Record<string, PotentialMinister> = {};
+    const ministerRoles: Record<string, string[]> = {};
+
+    let available = initialCandidates;
+
+    if (primeMinister) {
+      selectedMinisters['premier-ministre'] = primeMinister;
+      ministerRoles[primeMinister.id] = ['premier-ministre'];
+      available = initialCandidates.filter(c => c.id !== primeMinister.id);
+    }
+
     set({
       presidentParty,
       maxPartyMinistersAllowed: partyAllocations,
-      availableCandidates: initialCandidates, // Ajout des candidats à l'état
-      ministerRoles: {},
-      selectedMinisters: {}
+      availableCandidates: available,
+      ministerRoles,
+      selectedMinisters
     });
   },
 

--- a/src/store/gameState.ts
+++ b/src/store/gameState.ts
@@ -485,12 +485,24 @@ export const useGameState = create<GameState>((set, get) => ({
       const newStats = { ...state.playerStats };
       
       // Impact sur la popularité
-      newStats.popularity += (minister.popularity - 50) * 0.1;
-      
+      newStats.popularity += (minister.popularity - 50) * 0.1 + (minister.reputation - 50) * 0.05;
+
       // Impact sur la stabilité selon la loyauté
       if (minister.personality?.loyalty) {
         newStats.stability += (minister.personality.loyalty - 50) * 0.1;
       }
+
+      // Expérience du ministre
+      if (minister.experience) {
+        newStats.stability += minister.experience * 0.02;
+      }
+
+      // Effets spéciaux
+      Object.entries(minister.specialEffects || {}).forEach(([key, val]) => {
+        if (newStats[key] !== undefined) {
+          newStats[key] += val;
+        }
+      });
       
       // Impact spécifique au rôle (simplifié)
       const roleImpact = 0.1 * minister.competence;

--- a/src/types/cabinet.ts
+++ b/src/types/cabinet.ts
@@ -108,6 +108,8 @@ export interface PotentialMinister {
     charisma: number;
     stubbornness: number;
   };
+  experience: number;
+  reputation: number;
   background: string[];
   preferredRoles?: string[];
   specialEffects: Record<string, number>;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -11,5 +11,13 @@ export interface PotentialMinister {
   id: string;
   name: string;
   party: string;
-  // ... autres propriétés
+  experience: number;
+  reputation: number;
+  competence: number;
+  personality: {
+    loyalty: number;
+    ambition: number;
+    charisma: number;
+    stubbornness: number;
+  };
 }

--- a/src/utils/candidateGenerator.ts
+++ b/src/utils/candidateGenerator.ts
@@ -60,6 +60,8 @@ export function generateCandidates(
         name: randomName(),
         party,
         popularity: 30 + Math.random() * 40,
+        experience: Math.floor(Math.random() * 30),
+        reputation: Math.floor(40 + Math.random() * 60),
         competence,
         ideology: {
           liberal: ideology.liberal + (Math.random() * 20 - 10),

--- a/src/utils/seatDistribution.ts
+++ b/src/utils/seatDistribution.ts
@@ -1,0 +1,8 @@
+import { PRESET_PARTIES } from '../store/gameState';
+
+export function getSeatDistribution(): Record<string, number> {
+  return PRESET_PARTIES.reduce((acc, party) => {
+    acc[party.id] = party.seatsInParliament;
+    return acc;
+  }, {} as Record<string, number>);
+}


### PR DESCRIPTION
## Summary
- centralize parliament seat distribution
- persist prime minister choice in cabinet formation
- skip PM position during minister selection
- show reputation and experience on candidate cards
- factor new attributes into nomination effects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Parameter implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68496ce23c10832cbb0e3e927b6001f3