### PR TITLE
Fix candidate type usage

### DIFF
--- a/components/CabinetFormation.tsx
+++ b/components/CabinetFormation.tsx
@@ -4,21 +4,6 @@ import { useCabinetFormationStore } from '../src/store/cabinetFormationStore';
 import type { PotentialMinister } from '../src/types/cabinet';
 import '../src/styles/CabinetFormation.css';
 
-interface MinisterCandidate {
-  id: string;
-  name: string;
-  party: string;
-  competence: number;
-  personality: {
-    loyalty: number;
-    ambition: number;
-    charisma: number;
-    stubbornness: number;
-  };
-  background: string;
-  specialEffects: Record<string, number>;
-}
-
 interface CabinetFormationProps {
   onComplete: () => void;
 }

--- a/src/types/cabinet.ts
+++ b/src/types/cabinet.ts
@@ -36,22 +36,6 @@ export interface Minister {
   status: 'active' | 'dismissed' | 'resigned';
 }
 
-interface MinisterCandidate {
-  id: string;
-  name: string;
-  party: string;
-  competence: number;
-  personality: {
-    loyalty: number;
-    ambition: number;
-    charisma: number;
-    stubbornness: number;
-  };
-  traits: string[];
-  background: string;
-  specialEffects: Record<string, number>;
-}
-
 export interface MinisterMission {
   id: string;
   title: string;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -7,17 +7,4 @@ export interface PoliticalParty {
   seats: number;
 }
 
-export interface PotentialMinister {
-  id: string;
-  name: string;
-  party: string;
-  experience: number;
-  reputation: number;
-  competence: number;
-  personality: {
-    loyalty: number;
-    ambition: number;
-    charisma: number;
-    stubbornness: number;
-  };
-}
+export type { PotentialMinister } from './cabinet';


### PR DESCRIPTION
## Summary
- drop unused `MinisterCandidate` interfaces
- re-export `PotentialMinister` from `types/game`
- rely on single PotentialMinister definition in store and components

## Testing
- `npm run build` *(fails: Parameter implicit any, missing modules, etc.)*
- `npm run lint` *(fails: cannot find ESLint package)*

------
https://chatgpt.com/codex/tasks/task_e_686a90d08804832c93004ca5d68fd226